### PR TITLE
feat: Replace static map with interactive Leaflet map

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,66 +24,9 @@ body {
 #map-container {
     width: 80%;
     max-width: 800px;
-    height: auto;
+    height: 400px;
     border: 1px solid #ccc;
     margin: 20px auto;
-    position: relative;
-    overflow: hidden; /* Hide parts of the map that overflow the container */
-}
-
-#alhambra-map {
-    width: 100%;
-    height: auto;
-    display: block;
-}
-
-#user-marker {
-    position: absolute;
-    width: 15px;
-    height: 15px;
-    background-color: blue;
-    border-radius: 50%;
-    border: 2px solid white;
-    box-shadow: 0 0 5px rgba(0,0,0,0.5);
-    transform: translate(-50%, -50%); /* Center the marker */
-    display: none; /* Hidden until position is known */
-    z-index: 10;
-}
-
-.poi-marker {
-    position: absolute;
-    width: 20px;
-    height: 20px;
-    background-color: red;
-    border-radius: 50%;
-    border: 2px solid white;
-    box-shadow: 0 0 5px rgba(0,0,0,0.5);
-    transform: translate(-50%, -50%);
-    z-index: 9;
-    cursor: pointer;
-}
-
-.poi-marker .poi-label {
-    position: absolute;
-    bottom: 25px;
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: white;
-    padding: 2px 5px;
-    border-radius: 3px;
-    font-size: 12px;
-    white-space: nowrap;
-    display: none; /* Hidden by default, shown on hover */
-}
-
-.poi-marker:hover .poi-label, .poi-marker.active .poi-label {
-    display: block;
-}
-
-.poi-marker.active {
-    background-color: #ffeb3b; /* Yellow */
-    transform: translate(-50%, -50%) scale(1.2);
-    z-index: 11;
 }
 
 #guide-text {

--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
     <title>Alhambra Voice Guide</title>
     <link rel="stylesheet" href="css/style.css">
 
+    <!-- Leaflet Map Support -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+
     <!-- PWA Support -->
     <link rel="manifest" href="/manifest.json">
     <meta name="theme-color" content="#8B0000"/>
@@ -28,7 +31,7 @@
     <h1 data-key="title">Alhambra Voice Guide</h1>
 
     <div id="map-container">
-        <img src="assets/alhambra-map.svg" alt="Alhambra Map" id="alhambra-map">
+        <!-- The interactive map will be rendered here -->
     </div>
 
     <div id="guide-text">
@@ -41,6 +44,7 @@
         <button id="stop-btn" data-key="stop">Stop</button>
     </div>
 
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
     <script src="js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This commit refactors the entire mapping functionality of the application.

The previous implementation used a static SVG image with manually positioned DOM elements for markers. This was replaced with an interactive map using the Leaflet.js library and OpenStreetMap tiles.

Key changes:
- Integrated Leaflet.js library via CDN.
- Replaced the static SVG map with a dynamic Leaflet map.
- Refactored all marker logic (user and POIs) to use the Leaflet API.
- Implemented your request to display the spoken POI description in the guide text area.
- Removed obsolete CSS and JavaScript code related to the old implementation.