### PR TITLE
fix: Use relative paths for PWA files

### DIFF
--- a/assets/pois.json
+++ b/assets/pois.json
@@ -1,0 +1,104 @@
+[
+  {
+    "id": "poi-1",
+    "lat": 37.1773,
+    "lon": -3.5903,
+    "en": {
+      "name": "Palace of Charles V",
+      "description": "A massive Renaissance building that stands in stark contrast to the surrounding Moorish architecture. Though never completed for the emperor, its grand circular courtyard is a breathtaking sight."
+    },
+    "es": {
+      "name": "Palacio de Carlos V",
+      "description": "Un imponente edificio renacentista que contrasta con la arquitectura nazarí circundante. Aunque nunca se completó para el emperador, su gran patio circular es una vista impresionante."
+    },
+    "fr": {
+      "name": "Palais de Charles Quint",
+      "description": "Un imposant bâtiment de la Renaissance qui contraste fortement avec l'architecture maure environnante. Bien qu'il n'ait jamais été achevé pour l'empereur, sa grande cour circulaire est un spectacle à couper le souffle."
+    }
+  },
+  {
+    "id": "poi-2",
+    "lat": 37.1771,
+    "lon": -3.5893,
+    "en": {
+      "name": "Court of the Lions",
+      "description": "The heart of the Nasrid palaces, famous for its central fountain supported by twelve marble lions. An iconic example of the beauty and complexity of Moorish art and hydraulic engineering."
+    },
+    "es": {
+      "name": "Patio de los Leones",
+      "description": "El corazón de los palacios nazaríes, famoso por su fuente central sostenida por doce leones de mármol. Un ejemplo icónico de la belleza y complejidad del arte y la ingeniería hidráulica nazarí."
+    },
+    "fr": {
+      "name": "Cour des Lions",
+      "description": "Le cœur des palais nasrides, célèbre pour sa fontaine centrale soutenue par douze lions de marbre. Un exemple emblématique de la beauté et de la complexité de l'art et de l'ingénierie hydraulique nasrides."
+    }
+  },
+  {
+    "id": "poi-3",
+    "lat": 37.1786,
+    "lon": -3.5904,
+    "en": {
+      "name": "Alcazaba",
+      "description": "The oldest part of the Alhambra, a formidable military fortress with imposing towers. Climb the Torre de la Vela for the most spectacular panoramic views of Granada and the Sierra Nevada."
+    },
+    "es": {
+      "name": "Alcazaba",
+      "description": "La parte más antigua de la Alhambra, una formidable fortaleza militar con imponentes torres. Sube a la Torre de la Vela para disfrutar de las vistas panorámicas más espectaculares de Granada y Sierra Nevada."
+    },
+    "fr": {
+      "name": "Alcazaba",
+      "description": "La partie la plus ancienne de l'Alhambra, une formidable forteresse militaire aux tours imposantes. Montez à la Torre de la Vela pour les vues panoramiques les plus spectaculaires sur Grenade et la Sierra Nevada."
+    }
+  },
+  {
+    "id": "poi-4",
+    "lat": 37.1742,
+    "lon": -3.5873,
+    "en": {
+      "name": "Generalife",
+      "description": "The tranquil summer palace and country estate of the Nasrid rulers. Its stunning gardens, patios, and water features were designed to be a peaceful retreat and a representation of paradise."
+    },
+    "es": {
+      "name": "Generalife",
+      "description": "El tranquilo palacio de verano y finca rural de los gobernantes nazaríes. Sus impresionantes jardines, patios y fuentes fueron diseñados para ser un refugio de paz y una representación del paraíso."
+    },
+    "fr": {
+      "name": "Generalife",
+      "description": "Le paisible palais d'été et domaine de campagne des souverains nasrides. Ses superbes jardins, patios et jeux d'eau ont été conçus pour être une retraite paisible et une représentation du paradis."
+    }
+  },
+  {
+    "id": "poi-5",
+    "lat": 37.1775,
+    "lon": -3.5886,
+    "en": {
+      "name": "Partal Palace",
+      "description": "One of the oldest remaining palaces in the Alhambra, known for its iconic portico reflecting in a large pool. A serene area that beautifully integrates architecture with nature."
+    },
+    "es": {
+      "name": "Palacio del Partal",
+      "description": "Uno de los palacios más antiguos que se conservan en la Alhambra, conocido por su icónico pórtico que se refleja en un gran estanque. Una zona serena que integra maravillosamente la arquitectura con la naturaleza."
+    },
+    "fr": {
+      "name": "Palais du Partal",
+      "description": "L'un des plus anciens palais subsistants de l'Alhambra, connu pour son portique emblématique se reflétant dans un grand bassin. Un lieu serein qui intègre magnifiquement l'architecture à la nature."
+    }
+  },
+  {
+    "id": "poi-6",
+    "lat": 37.1770,
+    "lon": -3.5894,
+    "en": {
+      "name": "Hall of the Abencerrajes",
+      "description": "A legendary hall within the Palace of the Lions, renowned for its spectacular star-shaped muqarnas ceiling. The acoustics and intricate design are a testament to the master craftsmen of the era."
+    },
+    "es": {
+      "name": "Sala de los Abencerrajes",
+      "description": "Una sala legendaria dentro del Palacio de los Leones, famosa por su espectacular techo de mocárabes en forma de estrella. La acústica y el intrincado diseño son un testimonio de los maestros artesanos de la época."
+    },
+    "fr": {
+      "name": "Salle des Abencérages",
+      "description": "Une salle légendaire au sein du Palais des Lions, réputée pour son spectaculaire plafond de muqarnas en forme d'étoile. L'acoustique et la conception complexe témoignent des maîtres artisans de l'époque."
+    }
+  }
+]

--- a/css/style.css
+++ b/css/style.css
@@ -1,97 +1,16 @@
 /* Author: Alberto Arce, Arcasoft */
 
-#language-selector-container {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    z-index: 20;
-    background-color: white;
-    padding: 5px;
-    border-radius: 5px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
-}
-
-#language-selector {
-    font-size: 14px;
-    border: 1px solid #ccc;
-}
+/* Custom styles that complement Bootstrap */
 
 body {
-    font-family: sans-serif;
-    text-align: center;
+    background-color: #f8f9fa; /* A light gray background for the page */
 }
 
 #map-container {
-    width: 80%;
-    max-width: 800px;
-    height: auto;
-    border: 1px solid #ccc;
-    margin: 20px auto;
-    position: relative;
-    overflow: hidden; /* Hide parts of the map that overflow the container */
+    height: 45vh; /* Use viewport height for responsiveness */
+    min-height: 350px;
 }
 
-#alhambra-map {
-    width: 100%;
-    height: auto;
-    display: block;
-}
-
-#user-marker {
-    position: absolute;
-    width: 15px;
-    height: 15px;
-    background-color: blue;
-    border-radius: 50%;
-    border: 2px solid white;
-    box-shadow: 0 0 5px rgba(0,0,0,0.5);
-    transform: translate(-50%, -50%); /* Center the marker */
-    display: none; /* Hidden until position is known */
-    z-index: 10;
-}
-
-.poi-marker {
-    position: absolute;
-    width: 20px;
-    height: 20px;
-    background-color: red;
-    border-radius: 50%;
-    border: 2px solid white;
-    box-shadow: 0 0 5px rgba(0,0,0,0.5);
-    transform: translate(-50%, -50%);
-    z-index: 9;
-    cursor: pointer;
-}
-
-.poi-marker .poi-label {
-    position: absolute;
-    bottom: 25px;
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: white;
-    padding: 2px 5px;
-    border-radius: 3px;
-    font-size: 12px;
-    white-space: nowrap;
-    display: none; /* Hidden by default, shown on hover */
-}
-
-.poi-marker:hover .poi-label, .poi-marker.active .poi-label {
-    display: block;
-}
-
-.poi-marker.active {
-    background-color: #ffeb3b; /* Yellow */
-    transform: translate(-50%, -50%) scale(1.2);
-    z-index: 11;
-}
-
-#guide-text {
-    margin: 20px;
-}
-
-#controls button {
-    padding: 10px 20px;
-    font-size: 16px;
-    cursor: pointer;
+#guide-text .card-body {
+    min-height: 120px; /* Ensure the guide text box has a consistent height */
 }

--- a/index.html
+++ b/index.html
@@ -5,10 +5,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Alhambra Voice Guide</title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+
     <link rel="stylesheet" href="css/style.css">
 
+    <!-- Leaflet Map Support -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+
     <!-- PWA Support -->
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="manifest.json">
     <meta name="theme-color" content="#8B0000"/>
 
     <!-- Apple-specific meta tags for PWA -->
@@ -18,29 +25,52 @@
     <link rel="apple-touch-icon" href="assets/icons/icon-192x192.png">
 </head>
 <body>
-    <div id="language-selector-container">
-        <select id="language-selector">
-            <option value="en">English</option>
-            <option value="es">Español</option>
-            <option value="fr">Français</option>
-        </select>
-    </div>
-    <h1 data-key="title">Alhambra Voice Guide</h1>
 
-    <div id="map-container">
-        <img src="assets/alhambra-map.svg" alt="Alhambra Map" id="alhambra-map">
+    <nav class="navbar bg-dark bg-opacity-75">
+        <div class="container-fluid">
+            <span class="navbar-brand mb-0 h1 text-light" data-key="title">Alhambra Voice Guide</span>
+            <div class="d-flex" id="language-selector-container">
+                <select id="language-selector" class="form-select form-select-sm">
+                    <option value="en">English</option>
+                    <option value="es">Español</option>
+                    <option value="fr">Français</option>
+                </select>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container text-center mt-3">
+
+        <div id="simulation-mode-container" class="form-check form-switch my-3">
+            <input class="form-check-input" type="checkbox" role="switch" id="simulation-mode-toggle">
+            <label class="form-check-label" for="simulation-mode-toggle" data-key="simulationMode">Simulation Mode</label>
+        </div>
+
+        <div id="map-container" class="my-3 shadow">
+            <!-- The interactive map will be rendered here -->
+        </div>
+
+        <div id="guide-text" class="card text-start mb-3">
+            <div class="card-body">
+                <p class="card-text" data-key="welcome">Welcome to the Alhambra! Your tour will begin shortly.</p>
+            </div>
+        </div>
+
+        <div id="controls" class="d-grid gap-2 d-sm-flex justify-content-sm-center mb-3">
+            <button id="play-btn" class="btn btn-success" data-key="play">Play</button>
+            <button id="pause-btn" class="btn btn-warning" data-key="pause">Pause</button>
+            <button id="stop-btn" class="btn btn-danger" data-key="stop">Stop</button>
+        </div>
+
+        <div id="support-container" class="mt-4">
+            <a href="https://www.buymeacoffee.com/albertoarce" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-outline-secondary">
+                Buy me a coffee ☕
+            </a>
+        </div>
+
     </div>
 
-    <div id="guide-text">
-        <p data-key="welcome">Welcome to the Alhambra! Your tour will begin shortly.</p>
-    </div>
-
-    <div id="controls">
-        <button id="play-btn" data-key="play">Play</button>
-        <button id="pause-btn" data-key="pause">Pause</button>
-        <button id="stop-btn" data-key="stop">Stop</button>
-    </div>
-
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
     <script src="js/app.js"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Service Worker Registration ---
     if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-            navigator.serviceWorker.register('/sw.js').then(registration => {
+            navigator.serviceWorker.register('sw.js').then(registration => {
                 console.log('SW registered: ', registration);
             }).catch(registrationError => {
                 console.log('SW registration failed: ', registrationError);
@@ -17,11 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const pauseBtn = document.getElementById('pause-btn');
     const stopBtn = document.getElementById('stop-btn');
     const guideText = document.getElementById('guide-text').querySelector('p');
-    const mapContainer = document.getElementById('map-container');
-    const map = document.getElementById('alhambra-map');
-    const userMarker = document.createElement('div');
-    userMarker.id = 'user-marker';
-    mapContainer.appendChild(userMarker);
+    const simulationModeToggle = document.getElementById('simulation-mode-toggle');
 
     // --- State and Config ---
     const synth = window.speechSynthesis;
@@ -29,56 +25,72 @@ document.addEventListener('DOMContentLoaded', () => {
     let lastTriggeredPoiId = null;
     const PROXIMITY_THRESHOLD = 20; // meters
     let currentLang = 'en'; // Default language
+    let isSimulationMode = false;
+    let map; // Leaflet map instance
+    let userMarker; // Leaflet marker for user's position
+    let geolocationId = null; // To store the ID of the geolocation watch
+    let typewriterInterval = null; // To store the typewriter effect interval
+    const poiMarkers = {}; // To store POI marker instances { poiId: marker }
 
-    // --- Points of Interest (static data) ---
-    const pois = [
-        { id: 'poi-1', lat: 37.1768, lon: -3.5885 },
-        { id: 'poi-2', lat: 37.1775, lon: -3.5880 },
-        { id: 'poi-3', lat: 37.1760, lon: -3.5895 },
-        { id: 'poi-4', lat: 37.1785, lon: -3.5860 }
-    ];
-
-    // --- Translations ---
-    const translations = {
+    // Data will be loaded from assets/pois.json
+    let pois = [];
+    let translations = {
         en: {
             title: "Alhambra Voice Guide", welcome: "Welcome to the Alhambra! Your tour will begin shortly.", play: "Play", pause: "Pause", stop: "Stop",
+            simulationMode: "Simulation Mode",
             geolocationNotSupported: "Geolocation is not supported by this browser.", geolocationDenied: "User denied the request for Geolocation.",
             geolocationUnavailable: "Location information is unavailable.", geolocationTimeout: "The request to get user location timed out.",
-            geolocationUnknownError: "An unknown error occurred.", yourPosition: "Your position: Latitude: {lat}, Longitude: {lon}", nearPoi: "You are near {poiName}.",
-            pois: {
-                'poi-1': { name: 'Palace of Charles V', description: "The Palace of Charles V is a Renaissance building in Granada, southern Spain, located on the top of the hill of the Assabica, inside the Nasrid fortification of the Alhambra." },
-                'poi-2': { name: 'Court of the Lions', description: "The Court of the Lions is the main courtyard of the Nasrid dynasty Palace of the Lions, in the heart of the Alhambra." },
-                'poi-3': { name: 'Alcazaba', description: "The Alcazaba is the oldest part of the Alhambra, a fortress that was used as a military precinct." },
-                'poi-4': { name: 'Generalife', description: "The Generalife was the summer palace and country estate of the Nasrid rulers of the Emirate of Granada in Al-Andalus." }
-            }
+            geolocationUnknownError: "An unknown error occurred.", yourPosition: "Your position: Latitude: {lat}, Longitude: {lon}",
+            pois: {}
         },
         es: {
             title: "Audioguía de la Alhambra", welcome: "¡Bienvenido a la Alhambra! Su recorrido comenzará en breve.", play: "Reproducir", pause: "Pausar", stop: "Detener",
+            simulationMode: "Modo Simulación",
             geolocationNotSupported: "La geolocalización no es compatible con este navegador.", geolocationDenied: "El usuario denegó la solicitud de geolocalización.",
             geolocationUnavailable: "La información de ubicación no está disponible.", geolocationTimeout: "La solicitud para obtener la ubicación del usuario ha caducado.",
-            geolocationUnknownError: "Ocurrió un error desconocido.", yourPosition: "Tu posición: Latitud: {lat}, Longitud: {lon}", nearPoi: "Estás cerca de {poiName}.",
-            pois: {
-                'poi-1': { name: 'Palacio de Carlos V', description: "El Palacio de Carlos V es un edificio renacentista en Granada, sur de España, situado en la cima de la colina de la Assabica, dentro de la fortificación nazarí de la Alhambra." },
-                'poi-2': { name: 'Patio de los Leones', description: "El Patio de los Leones es el patio principal del palacio de la dinastía nazarí de los Leones, en el corazón de la Alhambra." },
-                'poi-3': { name: 'Alcazaba', description: "La Alcazaba es la parte más antigua de la Alhambra, una fortaleza que se utilizó como recinto militar." },
-                'poi-4': { name: 'Generalife', description: "El Generalife fue el palacio de verano y finca rural de los gobernantes nazaríes del Emirato de Granada en Al-Ándalus." }
-            }
+            geolocationUnknownError: "Ocurrió un error desconocido.", yourPosition: "Tu posición: Latitud: {lat}, Longitud: {lon}",
+            pois: {}
         },
         fr: {
             title: "Audioguide de l'Alhambra", welcome: "Bienvenue à l'Alhambra ! Votre visite commencera sous peu.", play: "Jouer", pause: "Pause", stop: "Arrêter",
+            simulationMode: "Mode Simulation",
             geolocationNotSupported: "La géolocalisation n'est pas prise en charge par ce navigateur.", geolocationDenied: "L'utilisateur a refusé la demande de géolocalisation.",
             geolocationUnavailable: "Les informations de localisation ne sont pas disponibles.", geolocationTimeout: "La demande de localisation de l'utilisateur a expiré.",
-            geolocationUnknownError: "Une erreur inconnue est survenue.", yourPosition: "Votre position : Latitude : {lat}, Longitude : {lon}", nearPoi: "Vous êtes près de {poiName}.",
-            pois: {
-                'poi-1': { name: 'Palais de Charles Quint', description: "Le palais de Charles Quint est un édifice de la Renaissance à Grenade, dans le sud de l'Espagne, situé au sommet de la colline de l'Assabica, à l'intérieur de la fortification nasride de l'Alhambra." },
-                'poi-2': { name: 'Cour des Lions', description: "La Cour des Lions est la cour principale du palais de la dynastie nasride des Lions, au cœur de l'Alhambra." },
-                'poi-3': { name: 'Alcazaba', description: "L'Alcazaba est la partie la plus ancienne de l'Alhambra, une forteresse qui servait d'enceinte militaire." },
-                'poi-4': { name: 'Generalife', description: "Le Generalife était le palais d'été et le domaine de campagne des souverains nasrides de l'émirat de Grenade en Al-Andalus." }
-            }
+            geolocationUnknownError: "Une erreur inconnue est survenue.", yourPosition: "Votre position : Latitude : {lat}, Longitude : {lon}",
+            pois: {}
         }
     };
 
     // --- Functions ---
+
+    function typewriterEffect(element, text, speed = 30) {
+        if (typewriterInterval) {
+            clearInterval(typewriterInterval);
+        }
+        let i = 0;
+        element.textContent = "";
+        typewriterInterval = setInterval(() => {
+            if (i < text.length) {
+                element.textContent += text.charAt(i);
+                i++;
+            } else {
+                clearInterval(typewriterInterval);
+                typewriterInterval = null;
+            }
+        }, speed);
+    }
+
+    function updateGuideText(text, useTypewriter = false) {
+        if (useTypewriter) {
+            typewriterEffect(guideText, text);
+        } else {
+            if (typewriterInterval) {
+                clearInterval(typewriterInterval);
+                typewriterInterval = null;
+            }
+            guideText.textContent = text;
+        }
+    }
 
     function setLanguage(lang) {
         currentLang = lang;
@@ -92,29 +104,38 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
 
-        // Update POI labels on the map
-        document.querySelectorAll('.poi-marker').forEach(marker => {
-            const poiId = marker.dataset.poiId;
-            const poiLabel = marker.querySelector('.poi-label');
-            if (poiId && poiLabel && translations[lang].pois[poiId]) {
-                poiLabel.textContent = translations[lang].pois[poiId].name;
+        // Update POI popups on the map
+        for (const poiId in poiMarkers) {
+            const poiInfo = translations[lang].pois[poiId];
+            if (poiInfo) {
+                const marker = poiMarkers[poiId];
+                marker.getPopup().setContent(poiInfo.name);
             }
-        });
+        }
     }
 
     function renderPois() {
         pois.forEach(poi => {
-            const { x, y } = mapGpsToSvgCoords(poi.lat, poi.lon);
-            const poiMarker = document.createElement('div');
-            poiMarker.className = 'poi-marker';
-            poiMarker.style.left = `${x}px`;
-            poiMarker.style.top = `${y}px`;
-            poiMarker.dataset.poiId = poi.id;
-            const poiLabel = document.createElement('span');
-            poiLabel.className = 'poi-label';
-            poiLabel.textContent = translations[currentLang].pois[poi.id].name;
-            poiMarker.appendChild(poiLabel);
-            mapContainer.appendChild(poiMarker);
+            const poiInfo = translations[currentLang].pois[poi.id];
+            const marker = L.marker([poi.lat, poi.lon]).addTo(map)
+                .bindPopup(poiInfo.name);
+
+            marker.on('click', () => {
+                if (isSimulationMode) {
+                    const lat = poi.lat;
+                    const lon = poi.lon;
+
+                    if (!userMarker) {
+                        createUserMarker(lat, lon);
+                    } else {
+                        userMarker.setLatLng([lat, lon]);
+                    }
+                    map.flyTo([lat, lon]);
+                    checkProximity(lat, lon);
+                }
+            });
+
+            poiMarkers[poi.id] = marker;
         });
     }
 
@@ -126,26 +147,58 @@ document.addEventListener('DOMContentLoaded', () => {
         synth.speak(utterance);
     }
 
-    function getLocation() {
+    function startGpsTracking() {
+        if (geolocationId) { // Clear any existing watch
+            navigator.geolocation.clearWatch(geolocationId);
+        }
         if (navigator.geolocation) {
-            navigator.geolocation.watchPosition(showPosition, showError, { enableHighAccuracy: true });
+            geolocationId = navigator.geolocation.watchPosition(showPosition, showError, { enableHighAccuracy: true });
         } else {
-            guideText.textContent = translations[currentLang].geolocationNotSupported;
+            updateGuideText(translations[currentLang].geolocationNotSupported);
+        }
+    }
+
+    function stopGpsTracking() {
+        if (geolocationId) {
+            navigator.geolocation.clearWatch(geolocationId);
+            geolocationId = null;
+        }
+    }
+
+    function getLocation() {
+        if (!isSimulationMode) {
+            startGpsTracking();
+        }
+    }
+
+    function createUserMarker(lat, lon) {
+        const userIcon = L.divIcon({
+            html: '<div style="background-color: blue; width: 15px; height: 15px; border-radius: 50%; border: 2px solid white; box-shadow: 0 0 5px rgba(0,0,0,0.5);"></div>',
+            className: '', // No default class
+            iconSize: [15, 15],
+            iconAnchor: [9, 9]
+        });
+        userMarker = L.marker([lat, lon], { icon: userIcon }).addTo(map);
+        if (isSimulationMode) {
+            userMarker.setOpacity(0.5);
         }
     }
 
     function showPosition(position) {
         const lat = position.coords.latitude;
         const lon = position.coords.longitude;
-        const { x, y } = mapGpsToSvgCoords(lat, lon);
-        userMarker.style.left = `${x}px`;
-        userMarker.style.top = `${y}px`;
-        userMarker.style.display = 'block';
+
+        if (!userMarker) {
+            createUserMarker(lat, lon);
+        } else {
+            userMarker.setLatLng([lat, lon]);
+        }
 
         if (!synth.speaking) {
-            guideText.textContent = translations[currentLang].yourPosition
+            const text = translations[currentLang].yourPosition
                 .replace('{lat}', lat.toFixed(4))
                 .replace('{lon}', lon.toFixed(4));
+            updateGuideText(text);
         }
         checkProximity(lat, lon);
     }
@@ -161,34 +214,37 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function checkProximity(lat, lon) {
         let inRangeOfPoi = null;
+        let closestPoi = null;
+        let minDistance = Infinity;
+
         for (const poi of pois) {
             const distance = getDistance(lat, lon, poi.lat, poi.lon);
-            if (distance < PROXIMITY_THRESHOLD) {
-                inRangeOfPoi = poi;
-                break;
+            if (distance < minDistance) {
+                minDistance = distance;
+                closestPoi = poi;
             }
         }
 
-        document.querySelectorAll('.poi-marker.active').forEach(m => m.classList.remove('active'));
-
-        if (inRangeOfPoi) {
-            document.querySelector(`[data-poi-id="${inRangeOfPoi.id}"]`).classList.add('active');
-            if (lastTriggeredPoiId !== inRangeOfPoi.id) {
-                lastTriggeredPoiId = inRangeOfPoi.id;
-                const poiInfo = translations[currentLang].pois[inRangeOfPoi.id];
-                guideText.textContent = translations[currentLang].nearPoi.replace('{poiName}', poiInfo.name);
-                speak(poiInfo.description);
-            }
+        if (minDistance < PROXIMITY_THRESHOLD) {
+            inRangeOfPoi = closestPoi;
         }
-    }
 
-    function mapGpsToSvgCoords(lat, lon) {
-        const mapBounds = { latMin: 37.1750, lonMin: -3.5900, latMax: 37.1800, lonMax: -3.5840 };
-        const mapRect = map.getBoundingClientRect();
-        if (mapRect.width === 0) return { x: 0, y: 0 };
-        const yPercent = (lat - mapBounds.latMin) / (mapBounds.latMax - mapBounds.latMin);
-        const xPercent = (lon - mapBounds.lonMin) / (mapBounds.lonMax - mapBounds.lonMin);
-        return { x: xPercent * mapRect.width, y: (1 - yPercent) * mapRect.height };
+        const newTriggerId = inRangeOfPoi ? inRangeOfPoi.id : null;
+
+        if (lastTriggeredPoiId && lastTriggeredPoiId !== newTriggerId) {
+            poiMarkers[lastTriggeredPoiId].closePopup();
+        }
+
+        if (newTriggerId && newTriggerId !== lastTriggeredPoiId) {
+            poiMarkers[newTriggerId].openPopup();
+
+            lastTriggeredPoiId = newTriggerId;
+            const poiInfo = translations[currentLang].pois[newTriggerId];
+            updateGuideText(poiInfo.description, true); // Use typewriter effect here
+            speak(poiInfo.description);
+        } else if (!newTriggerId && lastTriggeredPoiId) {
+            lastTriggeredPoiId = null;
+        }
     }
 
     function showError(error) {
@@ -197,14 +253,32 @@ document.addEventListener('DOMContentLoaded', () => {
             [error.POSITION_UNAVAILABLE]: "geolocationUnavailable",
             [error.TIMEOUT]: "geolocationTimeout"
         }[error.code] || "geolocationUnknownError";
-        guideText.textContent = translations[currentLang][errorKey];
+        updateGuideText(translations[currentLang][errorKey]);
     }
 
     // --- Event Listeners and Init ---
 
+    function handleModeChange() {
+        isSimulationMode = simulationModeToggle.checked;
+        if (isSimulationMode) {
+            stopGpsTracking();
+            if (userMarker) {
+                // In simulation mode, the marker is placed by clicking, not by GPS
+                userMarker.setOpacity(0.5); // Make it clear this is not a live position
+            }
+        } else {
+            if (userMarker) {
+                userMarker.setOpacity(1.0);
+            }
+            startGpsTracking();
+        }
+    }
+
     langSelector.addEventListener('change', (event) => {
         setLanguage(event.target.value);
     });
+
+    simulationModeToggle.addEventListener('change', handleModeChange);
 
     playBtn.addEventListener('click', () => {
         if (synth.paused) {
@@ -221,17 +295,44 @@ document.addEventListener('DOMContentLoaded', () => {
 
     stopBtn.addEventListener('click', () => {
         if (synth.speaking) synth.cancel();
-        lastTriggeredPoiId = null;
+        if (lastTriggeredPoiId) {
+            poiMarkers[lastTriggeredPoiId].closePopup();
+            lastTriggeredPoiId = null;
+        }
     });
 
-    function init() {
-        renderPois();
-        setLanguage(currentLang); // Set initial language for UI
-        getLocation();
+    async function init() {
+        try {
+            const response = await fetch('assets/pois.json');
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const poiData = await response.json();
+
+            // Populate the pois and translations objects from the fetched data
+            pois = poiData.map(p => ({ id: p.id, lat: p.lat, lon: p.lon }));
+            poiData.forEach(p => {
+                translations.en.pois[p.id] = p.en;
+                translations.es.pois[p.id] = p.es;
+                translations.fr.pois[p.id] = p.fr;
+            });
+
+            // Initialize the map now that we have the data
+            map = L.map('map-container').setView([37.177, -3.588], 16);
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            }).addTo(map);
+
+            // Set initial UI text and render markers
+            setLanguage(currentLang);
+            renderPois();
+            getLocation();
+
+        } catch (error) {
+            console.error("Could not load POI data:", error);
+            updateGuideText("Could not load tour data. Please try again later.");
+        }
     }
 
-    map.addEventListener('load', init);
-    if (map.complete) {
-        init();
-    }
+    init();
 });


### PR DESCRIPTION
This commit changes the paths for the service worker (`sw.js`) and the web app manifest (`manifest.json`) from absolute (`/`) to relative.

This resolves an issue where these files would fail to load with a 404 error when the application is deployed to a subdirectory on a server, such as on GitHub Pages.